### PR TITLE
Added a Docker image that builds from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:latest
+
+# Copy Dockerfile as documention
+COPY Dockerfile /
+
+# Copy the script that will be used to build
+# the fork of rdesktop from source.
+COPY docker/setup.sh /opt/setup.sh
+
+# The patched fork of rdesktop
+COPY rdesktop-fork-bd6aa6acddf0ba640a49834807872f4cc0d0a773 /opt/rdesktop
+
+RUN /opt/setup.sh
+
+# This will be used by Xvfb so that rdesktop
+# can run inside the container.
+ENV DISPLAY :99
+
+COPY docker/entrypoint.sh /opt/entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/opt/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,16 @@ make
 ./rdesktop 192.168.1.7:3389
 ```
 
-This fork of rdesktop is only well supported on an **X11 GUI Linux environment**. Results will vary for other platforms.
+This fork of rdesktop is only well supported on an **X11 GUI Linux environment** if you do not run the provided Docker image. Results will vary for other platforms.
+Please refer to the normal rdesktop compilation instructions or have a look at how the Docker image is built.
+=======
+You can also build from source using the Dockerfile and then run rdesktop using that image:
+
+```
+docker build . -t cve-2019-0708:latest
+docker run cve-2019-0708:latest 192.168.1.7:3389
+
+```
 
 ### Is this dangerous?
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+Xvfb :99 -screen 0 1024x768x16 &
+
+# Check if Xvfb has started correctly yet or
+# if we have to sleep for a while.
+for i in {0..10}; do
+    if [[ ! -d /tmp/.X11-unix ]]; then
+        sleep 0.1
+    else
+        break
+    fi
+done
+
+# Use exec here so that we can send signals to abort
+exec /opt/rdesktop/rdesktop "${1}"

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,36 @@
+export DEBIAN_FRONTEND noninteractive
+
+# Add sources so we can get the build requirements for rdesktop
+echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list
+echo 'deb-src http://security.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+echo 'deb-src http://deb.debian.org/debian stretch-updates main' >> /etc/apt/sources.list
+
+# Update the image and install common tools for debugging
+apt-get update && \
+    apt-get -y dist-upgrade && \
+    apt-get install -y \
+      iputils-ping \
+      procps \
+      bind9-host \
+      netcat-openbsd \
+
+# Install requirements for building rdesktop
+apt-get -y build-dep rdesktop
+
+# Install Xvfb to emulate the requirement that rdesktop
+# needs to work on a regular host with a display.
+apt-get -y install xvfb
+
+# Fix for the error "Failed to open keymap xx-yy"
+mkdir -p /root/.rdesktop/keymaps
+cp /opt/rdesktop/keymaps/* /root/.rdesktop/keymaps/
+
+# Start the build of the patched rdesktop fork
+cd /opt/rdesktop
+
+# Remove the pre-compiled version
+rm rdesktop
+
+./bootstrap
+./configure --disable-credssp --disable-smartcard
+make


### PR DESCRIPTION
and also allows rdesktop to run in an container, e.g.:
$ docker build . -t cve-2019-0708:latest
$ docker run cve-2019-0708:latest 192.168.1.7:3389
[+] Registering MS_T120 channel.
[+] Connection established using SSL.
[+] Sending MS_T120 check packet (size: 0x20 - offset: 0x8)
[+] Sending MS_T120 check packet (size: 0x10 - offset: 0x4)
[!] Target is VULNERABLE!!!