### PR TITLE
docs: fix simple typo, onwership -> ownership

### DIFF
--- a/scanner/rdesktop-fork-bd6aa6acddf0ba640a49834807872f4cc0d0a773/xclip.c
+++ b/scanner/rdesktop-fork-bd6aa6acddf0ba640a49834807872f4cc0d0a773/xclip.c
@@ -848,7 +848,7 @@ xclip_handle_SelectionRequest(XSelectionRequestEvent * event)
    is offered by the RDP server (and when it is pasted inside RDP, there's no network
    roundtrip).
 
-   This event (SelectionClear) symbolizes this rdesktop lost onwership of the clipboard
+   This event (SelectionClear) symbolizes this rdesktop lost ownership of the clipboard
    to some other X client. We should find out what clipboard formats this other
    client offers and announce that to RDP. */
 void


### PR DESCRIPTION
There is a small typo in scanner/rdesktop-fork-bd6aa6acddf0ba640a49834807872f4cc0d0a773/xclip.c.

Should read `ownership` rather than `onwership`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md